### PR TITLE
Fix bad warning check, and silence the warnings that triggered it.

### DIFF
--- a/dist/laserscad.scad
+++ b/dist/laserscad.scad
@@ -23,6 +23,27 @@ _lengrave_color = "MediumSpringGreen";
 _bounding_box_color = "Magenta";
 _bounding_box_alpha = 0.6;
 
+_lkerf_default = 0;
+_lmargin_default = 2;
+_lidentify_default = false;
+
+_lkerf_undef = is_undef(lkerf);
+_lmargin_undef = is_undef(lmargin);
+_lidentify_undef = is_undef(lidentify);
+
+lkerf = _lkerf_undef ? _lkerf_default : lkerf;
+lmargin = _lmargin_undef ? _lmargin_default : lmargin;
+lidentify = _lidentify_undef ? _lidentify_default : lidentify;
+
+_laserscad_var_sanity_check(_lkerf_undef, "lkerf", _lkerf_default);
+_laserscad_var_sanity_check(_lmargin_undef, "lmargin", _lmargin_default);
+_laserscad_var_sanity_check(_lidentify_undef, "lidentify", _lidentify_default);
+
+module _laserscad_var_sanity_check(undefined, name, default) {
+    if (undefined && _laserscad_mode <= 1) {
+        echo(str("Variable \"", name, "\" was not specified. Using default value ", default, "."));
+    }
+}
 
 // ############### VERSION CHECK UTILITIES ################
 
@@ -137,20 +158,12 @@ module lpart(id, dims) {
 // overwritten once optimal translations are known after packing
 function _lpart_translation(id) = [0,0,0];
 
-_lkerf_default = 0;
-_lmargin_default = 2;
-_lidentify_default = false;
-
 // actual lpart after sanity checks
-module _lpart_sane(id, dims) {   
+module _lpart_sane(id, dims) {
     if (_laserscad_mode <= 0) {
         // dev phase: all children shown, all operators apply
         children();
     } else {
-        lkerf = lkerf == undef? _lkerf_default : lkerf;
-        lmargin = lmargin == undef? _lmargin_default : lmargin;
-        lidentify = lidentify == undef? _lidentify_default : lidentify;
-
         if (_laserscad_mode == 1) {
             // pack phase: echo all the lpart dimensions
             ext_dims = dims + 2 * (lkerf + lmargin) * [1,1];
@@ -223,19 +236,6 @@ module _lslice_sane(id, dims, z, thickness) {
 
 
 // ########### MORE HINTS AND WARNINGS ############
-
-// print hints in dev and pack mode if variables are undefined
-if (_laserscad_mode <= 1) {
-    _laserscad_var_sanity_check(lkerf, "lkerf", _lkerf_default);
-    _laserscad_var_sanity_check(lmargin, "lmargin", _lmargin_default);
-    _laserscad_var_sanity_check(lidentify, "lidentify", _lidentify_default);
-}
-
-module _laserscad_var_sanity_check(var, name, default) {
-    if (var==undef) {
-        echo(str("Variable \"", name, "\" was not specified. Using default value ", default, "."));
-    }    
-}
 
 function _laserscad_stack() = str([for (i=[$parent_modules-1:-1:0]) parent_module(i)]);
 

--- a/dist/util/extract_bounding_boxes.py
+++ b/dist/util/extract_bounding_boxes.py
@@ -33,7 +33,7 @@ def extract(src, dest):
 		fail("OpenSCAD reports:" + prefix + prefix.join(messages["ERROR"]))
 
 	if "WARNING" in messages:
-		is_laserscad_missing = any("laserscad.scad" in m for m in messages["WARNING"])
+		is_laserscad_missing = any("cannot find 'laserscad.scad'" in m for m in messages["WARNING"])
 		if is_laserscad_missing:
 			fail("Error: OpenSCAD cannot find 'laserscad.scad'. Put 'laserscad.scad' in the OpenSCAD libraries folder or in the same folder as your model.")
 		else:


### PR DESCRIPTION
I'm guessing this is behavior that changed in OpenSCAD 2019.05: referencing unknown variables causes a warning to be emitted, unless you use the magical is_undef function to do so. This results in an empty `include <laserscad.scad>` generating these warnings:

```
WARNING: Ignoring unknown variable 'lkerf', in file .local/share/OpenSCAD/libraries/laserscad.scad, line 229.
WARNING: Ignoring unknown variable 'lidentify', in file .local/share/OpenSCAD/libraries/laserscad.scad, line 152.
WARNING: Ignoring unknown variable 'lmargin', in file .local/share/OpenSCAD/libraries/laserscad.scad, line 230.
WARNING: Ignoring unknown variable 'lmargin', in file .local/share/OpenSCAD/libraries/laserscad.scad, line 151.
WARNING: Ignoring unknown variable 'lkerf', in file .local/share/OpenSCAD/libraries/laserscad.scad, line 150.
WARNING: Ignoring unknown variable 'lidentify', in file .local/share/OpenSCAD/libraries/laserscad.scad, line 231.
```

That then triggers a false positive in one of the dist scripts that wanted to look for `cannot find 'laserscad.scad'` but actually looked for `laserscad.scad`.